### PR TITLE
Fix: Use relative API paths to resolve CORS error on www.weibo.com

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "新浪微博相册原图批量下载器",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "抓取新浪微博相册图片原图链接并批量下载。",
   "permissions": [
     "downloads",

--- a/src/content.js
+++ b/src/content.js
@@ -16,7 +16,7 @@ async function fetchImageAsBlob(url) {
 // Get user info from API (running in page context)
 async function getUserInfo(uid) {
   try {
-    const response = await fetch(`https://weibo.com/ajax/profile/info?uid=${uid}`, {
+    const response = await fetch(`/ajax/profile/info?uid=${uid}`, {
       credentials: 'include'
     });
 
@@ -95,7 +95,7 @@ async function fetchAllImagesViaAPI(uid) {
     const params = `uid=${uid}&has_album=1${sinceid ? '&sinceid=' + encodeURIComponent(sinceid) : ''}`;
     let data;
     try {
-      data = await fetchPageWithRetry(`https://weibo.com/ajax/profile/getImageWall?${params}`);
+      data = await fetchPageWithRetry(`/ajax/profile/getImageWall?${params}`);
     } catch (e) {
       partial = true;
       break;


### PR DESCRIPTION
1. Weibo now redirects users to `www.weibo.com`, causing absolute API URLs in the content script to trigger CORS errors —
   fixed by switching both API calls (`profile/info` and `profile/getImageWall`) to relative paths so they resolve
  against the current page origin, working correctly on both `weibo.com` and `www.weibo.com`.
2. Resolve #7 .